### PR TITLE
アセットパイプラインの処理を有効化

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
**What**
アセットパイプラインの処理を有効にした
具体的には、config/enviroments/production.rbの、config.assets.compile = falseをconfig.assets.compile = trueに変更した。

**Why**
本番環境で、登録した住所が緯度経度に変換されていなかった。
その理由としてアセットパイプラインがうまく行ってない可能性があるため。