### PR TITLE
スペルミスを修正

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,4 +1,4 @@
 Geocoder.configure(
   lookup: :google,
-  api_key: ENV['GOOGLE_MAP_API']
+  api_key: ENV['GOOGLE_API_KEY']
 )


### PR DESCRIPTION
**What**
スペルミスを訂正

**Why**
環境変数にGOOGLE_API_KEYとGOOGLE_MAP_APIが混在していたため、GOOGLE_API_KEYに統一